### PR TITLE
Use link to reference rustc static notes

### DIFF
--- a/src/arrays/index.md
+++ b/src/arrays/index.md
@@ -66,7 +66,7 @@ although they are probably quite familiar for people who've written C/C++ code
 before.
 
 Without further ado, lets compile the library.
-
+<span id="rustc-static-notes"></span>
 ```bash
 $ rustc --crate-type staticlib -o libaverages.a averages.rs
 note: link against the following native artifacts when linking against this static library
@@ -132,7 +132,7 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)
 Oops! When clang tried to compile our `libaverages.a` library and `main.c` into
 one executable it wasn't able to find a bunch of symbols.
 
-Remember those notes from earlier? That's what `rustc` was trying to warn us
+Remember those [notes] from earlier? That's what `rustc` was trying to warn us
 about. When you compile everything statically you need to include **all** your
 dependencies. You didn't have this issue when dynamically linking because the
 loader finds everything for you.
@@ -162,6 +162,6 @@ like `make` to help them build everything.
 
 Luckily in Rust, we can do one better...
 
-
+[notes]: arrays/#rustc-static-notes
 [from-raw-parts]: https://doc.rust-lang.org/nightly/std/slice/fn.from_raw_parts.html
 [mangling]: https://en.wikipedia.org/wiki/Name_mangling


### PR DESCRIPTION
#10 
I like this way better
Less text reformatting