### PR TITLE
Fix typo in rusage paragraph

### DIFF
--- a/src/structs/index.md
+++ b/src/structs/index.md
@@ -86,8 +86,8 @@ DESCRIPTION
 
 Obviously the `rusage` struct contains loads of juicy information about a 
 process, but only a small subset is needed, so to make things easier, a C
-library which calls `getrusage()` can be written that only gives us the
-info desired. In this case, only the resident memory, unshared stack size,
+library which calls `getrusage()` can be written so that it only gives us
+the info desired. In this case, only the resident memory, unshared stack size,
 and amount of time spent in user mode is needed.
 
 Here's the C shim example:


### PR DESCRIPTION
typo in 7518cc9
Rereading the rendered book a couple times before every commit
helped cut down on future typos and spot these.
Edit:  
Turns out the commit being viewed is at the bottom of the Github page.
It's not near the top right (that's the parent commit of it)