### PR TITLE
Replace usage of gcc with clang

### DIFF
--- a/src/arrays/index.md
+++ b/src/arrays/index.md
@@ -117,7 +117,7 @@ int main() {
 And now let's compile everything.
 
 ```bash
-$ gcc main.c libaverages.a
+$ clang main.c libaverages.a
 libaverages.a(std-9a66b6a343d52844.0.o): In function `std::sys::imp::mutex::{{impl}}::init':
 /checkout/src/libstd/sys/unix/mutex.rs:56: undefined reference to `pthread_mutexattr_init'
 /checkout/src/libstd/sys/unix/mutex.rs:58: undefined reference to `pthread_mutexattr_settype'

--- a/src/bindgen/index.md
+++ b/src/bindgen/index.md
@@ -20,6 +20,8 @@ use Rust in a C/C++ codebase in the first place!
 
 ## Getting Set Up
 
+> **Note:** Bindgen **requires** clang. Installation instructions can be found [here](https://github.com/rust-lang-nursery/rust-bindgen/blob/master/book/src/requirements.md#installing-clang-39)
+
 We'll be building on top of the [great tutorial][tut] linked earlier to write
 an idiomatic Rust wrapper around `bzip2`. This assumes you've already read
 through that tutorial and will focus more on the next step, writing the actual

--- a/src/introduction/Makefile
+++ b/src/introduction/Makefile
@@ -4,7 +4,7 @@ all: libhello.so main
 
 
 libhello.so: hello.c
-	gcc -shared -fPIC -o libhello.so hello.c
+	clang -shared -fPIC -o libhello.so hello.c
 
 main: libhello.so main.rs
 	rustc -l hello -L . main.rs

--- a/src/introduction/index.md
+++ b/src/introduction/index.md
@@ -109,7 +109,7 @@ external `say_hello` symbol will be resolved at *load time*.
 > [this Stack Overflow question][static-vs-dynamic].
 
 ```bash
-$ gcc -shared -fPIC -o libhello.so hello.c
+$ clang -shared -fPIC -o libhello.so hello.c
 ```
 
 > **Note:** clang and gcc are interchangeable when compiling.

--- a/src/introduction/index.md
+++ b/src/introduction/index.md
@@ -112,6 +112,8 @@ external `say_hello` symbol will be resolved at *load time*.
 $ gcc -shared -fPIC -o libhello.so hello.c
 ```
 
+> **Note:** clang and gcc are interchangeable when compiling.
+
 The `-shared` flag tells clang to compile as a dynamically linked library
 (typically "\*.so" on Linux or "\*.dll" on Windows). You'll also need the
 `-fPIC` flag to tell the compiler to generate [*Position Independent


### PR DESCRIPTION
closes #17 
Replace all usage of gcc commands with clang
Note that gcc can be used in place of clang
Add note that bindgen requires clang
