### PR TITLE
Simplify Primes class

### DIFF
--- a/src/pythonic/index.md
+++ b/src/pythonic/index.md
@@ -197,11 +197,10 @@ class Primes:
         return primal.primes_next(self.iterator)
 
     def __iter__(self):
-        running = True
-        while running:
-            prime = self.next()
+        prime = self.next()
+        while prime != 0:
             yield prime
-            running = prime != 0
+            prime = self.next()
 ```
 
 And finally the code to run it:
@@ -214,7 +213,8 @@ if __name__ == "__main__":
     with Primes() as p:
         n = 20
         primes = list(itertools.islice(p, n))
-        print('The first {} prime numbers are {}'.format(n, ', '.join(primes)))
+        print('The first {} prime numbers are {}'
+              .format(n, ', '.join([str(p) for p in primes])))
 ```
 
 If you were paying close attention when the Rust functions were first defined

--- a/src/pythonic/index.md
+++ b/src/pythonic/index.md
@@ -74,6 +74,10 @@ pub unsafe extern "C" fn primes_destroy(primes: *mut Primes) {
 /// # Remarks
 ///
 /// If zero is returned then there the iterator is finished.
+///
+/// # Panics
+///
+/// If `n` is greater than `upper_bound`
 #[no_mangle]
 pub unsafe extern "C" fn primes_next(primes: *mut Primes) -> libc::c_uint {
     (&mut *primes).next().unwrap_or(0)
@@ -172,7 +176,10 @@ class Sieve:
 
     def __exit__(self, *args):
         primal.sieve_destroy(self.sieve)
-
+```
+A Python `Exception` is preferable over rust panicking and
+unwinding, so `is_prime` checks if `n` exceeds `upper_bound`.
+```Python
     def is_prime(self, n):
         if n > self.upper_bound():
             raise IndexError("{} not in upper bound {}"
@@ -183,7 +190,7 @@ class Sieve:
         return primal.sieve_upper_bound(self.sieve)
 ```
 
-A similar thing is done for the prime number iterator, converting the 
+A similar wrapper is written around the prime number iterator, converting the
 repetitive `primes_next()` call into a more pythonic iterator with 
 `__iter__()`.
 

--- a/src/pythonic/index.md
+++ b/src/pythonic/index.md
@@ -174,6 +174,9 @@ class Sieve:
         primal.sieve_destroy(self.sieve)
 
     def is_prime(self, n):
+        if n > self.upper_bound():
+            raise IndexError("{} not in upper bound {}"
+                             .format(n, self.upper_bound()))
         return primal.sieve_is_prime(self.sieve, n) != 0
 
     def upper_bound(self):

--- a/src/pythonic/main.py
+++ b/src/pythonic/main.py
@@ -59,5 +59,7 @@ if __name__ == "__main__":
         print(s.is_prime(5))
 
     with Primes() as p:
-        first_20 = list(itertools.islice(p, 20))
-        print(first_20)
+        n = 20
+        primes = list(itertools.islice(p, n))
+        print('The first {} prime numbers are {}'
+              .format(n, ', '.join([str(p) for p in primes])))

--- a/src/pythonic/main.py
+++ b/src/pythonic/main.py
@@ -48,11 +48,10 @@ class Primes:
         return primal.primes_next(self.iterator)
 
     def __iter__(self):
-        running = True
-        while running:
-            prime = self.next()
+        prime = self.next()
+        while prime != 0:
             yield prime
-            running = prime != 0
+            prime = self.next()
 
 
 if __name__ == "__main__":

--- a/src/pythonic/main.py
+++ b/src/pythonic/main.py
@@ -30,6 +30,9 @@ class Sieve:
         primal.sieve_destroy(self.sieve)
 
     def is_prime(self, n):
+        if n > self.upper_bound():
+            raise IndexError("{} not in upper bound {}"
+                             .format(n, self.upper_bound()))
         return primal.sieve_is_prime(self.sieve, n) != 0
 
     def upper_bound(self):

--- a/src/pythonic/primes/src/lib.rs
+++ b/src/pythonic/primes/src/lib.rs
@@ -45,6 +45,9 @@ pub unsafe extern "C" fn primes_destroy(primes: *mut Primes) {
 /// # Remarks
 ///
 /// If zero is returned then there the iterator is finished.
+/// 
+/// # Panics
+/// If `n` is greater than `upper_bound`
 #[no_mangle]
 pub unsafe extern "C" fn primes_next(primes: *mut Primes) -> libc::c_uint {
     match (&mut *primes).next() {

--- a/src/pythonic/test_primes.py
+++ b/src/pythonic/test_primes.py
@@ -1,0 +1,28 @@
+import pytest
+import itertools
+from main import Primes, Sieve
+
+
+def test_sieve_limit():
+    limit = 10000
+    with Sieve(limit) as s:
+        assert s.upper_bound() >= limit
+
+
+def test_upper_bound_exception():
+    limit = 10
+    with Sieve(limit) as s:
+        with pytest.raises(IndexError):
+            s.is_prime(101)
+
+
+def test_zero_is_not_in_prime_list():
+    with Primes() as p:
+        n = 20
+        assert 0 not in list(itertools.islice(p, n))
+
+
+def test_number_primes_asked_is_given():
+    with Primes() as p:
+        n = 20
+        assert len(list(itertools.islice(p, n))) == n

--- a/src/pythonic/test_primes.py
+++ b/src/pythonic/test_primes.py
@@ -9,7 +9,7 @@ def test_sieve_limit():
         assert s.upper_bound() >= limit
 
 
-def test_upper_bound_exception():
+def test_checking_above_upper_bound_is_an_error():
     limit = 10
     with Sieve(limit) as s:
         with pytest.raises(IndexError):


### PR DESCRIPTION
closes #25 
closes #30 
Fixes #32 
I seem to prefer generators.
Here are what benefits I see.
1.  StopIteration is automatically raised when `Primes` stops yielding
2. Only one value is passed back at a time (memory savings)