### PR TITLE
Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ main_versions
 main_chars
 target
 Cargo.lock
+__pycache__
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ main
 main_versions
 main_chars
 target
+Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ cache:
 - pip
 before_cache:
   - chmod -R a+r $HOME/.cargo
-script: make all
+script: 
+  - make build
+  - make test
 after_success: ./ci/deploy.sh
 env:
   global:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = ["src/bindgen/bzip2",
+           "src/callbacks/app",
+           "src/dynamic_loading/loading",
+           "src/pythonic/primes",
+           "src/structs/get_usage"]

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,4 @@ open: book
 book:
 	mdbook build
 
-# This requires a hack so that we don't try to build bindgen 
-# when being run by Travis (it errors)
-bindgen:
-	if [ -z "$(TRAVIS_BRANCH)" ]; then \
-		cd src/bindgen/bzip2/ && cargo build; \
-	fi
-
-
-.PHONY: clean build book todo
+.PHONY: clean build test book todo word_count open

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,41 @@
 OPEN := xdg-open
-DIRS := $(shell find ./src -maxdepth 1 -type d)
-CC := clang
+DIRS := $(shell find ./src -mindepth 1 -maxdepth 1 -type d)
 
-
-define run-in-sub-dirs
-	for sub_dir in $(DIRS); do \
-		$(MAKE) -C $$sub_dir $1; \
-	done
-endef
+# Export some default variables that all sub-makefiles should use
+export OUTPUT_DIR := ${CURDIR}/target/debug
+export CC := clang
+export CFLAGS := -std=c99
 
 
 build:
-	$(call run-in-sub-dirs,build)
+	$(MAKE) -C src/arrays build
+	$(MAKE) -C src/bindgen build
+	$(MAKE) -C src/callbacks build
+	$(MAKE) -C src/dynamic_loading build
+	$(MAKE) -C src/introduction build
+	$(MAKE) -C src/pythonic build
+	$(MAKE) -C src/strings build
+	$(MAKE) -C src/structs build
 
 test:
-	$(call run-in-sub-dirs,test)
+	$(MAKE) -C src/arrays test
+	$(MAKE) -C src/bindgen test
+	$(MAKE) -C src/callbacks test
+	$(MAKE) -C src/dynamic_loading test
+	$(MAKE) -C src/introduction test
+	$(MAKE) -C src/pythonic test
+	$(MAKE) -C src/strings test
+	$(MAKE) -C src/structs test
 
 clean:
-	$(call run-in-sub-dirs,clean)
+	$(MAKE) -C src/arrays clean
+	$(MAKE) -C src/bindgen clean
+	$(MAKE) -C src/callbacks clean
+	$(MAKE) -C src/dynamic_loading clean
+	$(MAKE) -C src/introduction clean
+	$(MAKE) -C src/pythonic clean
+	$(MAKE) -C src/strings clean
+	$(MAKE) -C src/structs clean
 	cargo clean
 
 word_count:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,23 @@
 OPEN := xdg-open
+DIRS := $(shell find ./src -maxdepth 1 -type d)
+CC := clang
 
 
-all: book intro arrays structs pythonic strings bindgen dynamic_loading callbacks
+define run-in-sub-dirs
+	for sub_dir in $(DIRS); do \
+		$(MAKE) -C $$sub_dir $1; \
+	done
+endef
+
+
+build:
+	$(call run-in-sub-dirs build)
+
+test:
+	$(call run-in-sub-dirs test)
+
+clean:
+	$(call run-in-sub-dirs clean)
 
 word_count:
 	@find -name '*.md' -print0 | wc --files0-from=-
@@ -15,28 +31,6 @@ open: book
 book:
 	mdbook build
 
-intro:
-	$(MAKE) -C src/introduction
-
-arrays:
-	$(MAKE) -C src/arrays
-
-strings:
-	$(MAKE) -C src/strings
-
-dynamic_loading:
-	$(MAKE) -C src/dynamic_loading
-
-structs:
-	cd src/structs/get_usage/ && cargo build
-
-pythonic:
-	cd src/pythonic/primes/ && cargo build
-
-callbacks:
-	cd src/callbacks/app/ && cargo run
-	$(MAKE) -C src/callbacks
-
 # This requires a hack so that we don't try to build bindgen 
 # when being run by Travis (it errors)
 bindgen:
@@ -44,15 +38,5 @@ bindgen:
 		cd src/bindgen/bzip2/ && cargo build; \
 	fi
 
-
-clean:
-	rm -rf ./book/*
-	$(MAKE) -C src/introduction clean
-	$(MAKE) -C src/arrays clean
-	cd src/structs/get_usage/ && cargo clean
-	cd src/pythonic/primes/ && cargo clean
-	cd src/bindgen/bzip2/ && cargo clean
-	cd src/callbacks/app/ && cargo clean 
-	$(MAKE) -C src/callbacks clean
 
 .PHONY: clean build book todo

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,14 @@ endef
 
 
 build:
-	$(call run-in-sub-dirs build)
+	$(call run-in-sub-dirs,build)
 
 test:
-	$(call run-in-sub-dirs test)
+	$(call run-in-sub-dirs,test)
 
 clean:
-	$(call run-in-sub-dirs clean)
+	$(call run-in-sub-dirs,clean)
+	cargo clean
 
 word_count:
 	@find -name '*.md' -print0 | wc --files0-from=-

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ It should now be viewable at [http://localhost:3000/](http://localhost:3000/).
 If there's anything you feel is missing or could be
 improved, please [create an issue][issues]. Pull requests are welcome too!
 
+The repository has been designed so that each chapter has its own `Makefile`
+which defines three rules, `build`, `test`, and `clean`. This allows you to run 
+`make test` in the the top level directory and `make` will iterate through each
+chapter, building and testing the examples. As such, changes which add new
+files may need to update the chapter's `Makefile` so that it is tested
+automatically.
+
 
 [gh-pages]: https://michael-f-bryan.github.io/rust-ffi-guide/
 [issues]: https://github.com/Michael-F-Bryan/rust-ffi-guide/issues/new

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -6,4 +6,5 @@ else
   cargo install mdbook
 fi
 
-pip install --user ghp-import
+pip install --user ghp-import pytest cffi
+

--- a/src/arrays/Makefile
+++ b/src/arrays/Makefile
@@ -1,5 +1,8 @@
 
-all: libaverages.a main
+build: libaverages.a main
+
+test: build
+	./main | grep '123.5'
 
 libaverages.a: averages.rs
 	rustc --crate-type staticlib averages.rs

--- a/src/arrays/Makefile
+++ b/src/arrays/Makefile
@@ -8,7 +8,7 @@ libaverages.a: averages.rs
 	rustc --crate-type staticlib averages.rs
 
 main: main.c libaverages.a
-		clang -l dl \
+		$(CC) -l dl \
 		-l rt \
 		-l pthread \
 		-l gcc_s \

--- a/src/arrays/Makefile
+++ b/src/arrays/Makefile
@@ -8,7 +8,7 @@ libaverages.a: averages.rs
 	rustc --crate-type staticlib averages.rs
 
 main: main.c libaverages.a
-		$(CC) -l dl \
+		$(CC) $(CFLAGS) -l dl \
 		-l rt \
 		-l pthread \
 		-l gcc_s \

--- a/src/bindgen/Makefile
+++ b/src/bindgen/Makefile
@@ -1,3 +1,13 @@
+# This requires a hack so that we don't try to build bindgen 
+# when being run by Travis (it errors)
+ifdef TRAVIS_BRANCH
+
+build:
+test:
+clean:
+
+else
+
 build:
 	cd bzip2 && cargo build
 
@@ -6,5 +16,7 @@ test:
 
 clean:
 	cd bzip2 && cargo clean
+
+endif
 
 .PHONY: build test clean

--- a/src/bindgen/Makefile
+++ b/src/bindgen/Makefile
@@ -1,0 +1,10 @@
+build:
+	cd bzip2 && cargo build
+
+test:
+	cd bzip2 && cargo test
+
+clean:
+	cd bzip2 && cargo clean
+
+.PHONY: build test clean

--- a/src/callbacks/Makefile
+++ b/src/callbacks/Makefile
@@ -9,7 +9,7 @@ app:
 	cd app && cargo build
 
 main: main.c libfoo.so
-	$(CC) -L. -lfoo main.c -o main
+	$(CC) $(CFLAGS) -L. -lfoo main.c -o main
 
 lib%.so: %.rs
 	rustc --crate-type cdylib -o $@ $<

--- a/src/callbacks/Makefile
+++ b/src/callbacks/Makefile
@@ -1,17 +1,15 @@
-CC := clang
 
+build: app main
 
-all: app main
+test: main
+	cd app && cargo run | grep 'aborted early'
+	LD_LIBRARY_PATH=. ./main 2>&1 | grep 'index out of bounds' 
 
 app:
 	cd app && cargo build
 
 main: main.c libfoo.so
 	$(CC) -L. -lfoo main.c -o main
-
-run: main
-	cd app && cargo run
-	LD_LIBRARY_PATH=. ./main
 
 lib%.so: %.rs
 	rustc --crate-type cdylib -o $@ $<

--- a/src/callbacks/main.c
+++ b/src/callbacks/main.c
@@ -1,4 +1,5 @@
 #include <stddef.h>
+#include <assert.h>
 
 char get_item_10000(char *buffer, size_t len);
 char safe_get_item_10000(char *buffer, size_t len);
@@ -6,4 +7,6 @@ char safe_get_item_10000(char *buffer, size_t len);
 int main() {
   char buffer[50] = {};
   char got = safe_get_item_10000(buffer, 50);
+
+  assert(got == 0);
 }

--- a/src/dynamic_loading/Makefile
+++ b/src/dynamic_loading/Makefile
@@ -1,10 +1,10 @@
 LIBRARIES := libadder.so
 
 
-all: $(LIBRARIES) loading
+build: $(LIBRARIES) loading
 
-run: $(LIBRARIES)
-	cd loading && cargo run -- ../libadder.so
+test: $(LIBRARIES)
+	cd loading && cargo run -- ../libadder.so | grep '1 + 2 = 3'
 
 loading:
 	cd loading && cargo build
@@ -16,4 +16,4 @@ clean:
 	$(RM) $(LIBRARIES)
 	cd loading && cargo clean
 
-.PHONY: clean loading
+.PHONY: clean test loading

--- a/src/introduction/Makefile
+++ b/src/introduction/Makefile
@@ -1,10 +1,10 @@
+build: libhello.so main
 
-
-all: libhello.so main
-
+test: build
+	LD_LIBRARY_PATH=. ./main | grep 'Hello World'
 
 libhello.so: hello.c
-	clang -shared -fPIC -o libhello.so hello.c
+	$(CC) -shared -fPIC -o libhello.so hello.c
 
 main: libhello.so main.rs
 	rustc -l hello -L . main.rs
@@ -12,9 +12,5 @@ main: libhello.so main.rs
 clean:
 	$(RM) libhello.so
 	$(RM) main
-
-run: all
-	LD_LIBRARY_PATH=. ./main
-
 
 .PHONY: clean run

--- a/src/introduction/Makefile
+++ b/src/introduction/Makefile
@@ -4,7 +4,7 @@ test: build
 	LD_LIBRARY_PATH=. ./main | grep 'Hello World'
 
 libhello.so: hello.c
-	$(CC) -shared -fPIC -o libhello.so hello.c
+	$(CC) $(CFLAGS) -shared -fPIC -o libhello.so hello.c
 
 main: libhello.so main.rs
 	rustc -l hello -L . main.rs

--- a/src/pythonic/Makefile
+++ b/src/pythonic/Makefile
@@ -1,0 +1,10 @@
+build:
+	cd primes && cargo build
+
+test: build
+	@echo "TODO: update me to run py.test"
+
+clean: 
+	cd primes && cargo clean
+
+.PHONY: clean

--- a/src/pythonic/Makefile
+++ b/src/pythonic/Makefile
@@ -2,9 +2,10 @@ build:
 	cd primes && cargo build
 
 test: build
-	@echo "TODO: update me to run py.test"
+	py.test
 
 clean: 
 	cd primes && cargo clean
+	$(RM) -r ./__pycache__
 
 .PHONY: clean

--- a/src/pythonic/main.py
+++ b/src/pythonic/main.py
@@ -1,5 +1,12 @@
+import os
 import itertools
 from cffi import FFI
+
+# Make should set OUTPUT_DIR to the place where cargo put libprimes.so
+# otherwise we use a sensible default
+OUTPUT_DIR = os.environ.get('OUTPUT_DIR', "../../target/debug")
+DLL = OUTPUT_DIR + '/libprimes.so'
+
 
 ffi = FFI()
 
@@ -14,7 +21,7 @@ ffi.cdef("""
         unsigned int primes_next(void *primes);
         """)
 
-primal = ffi.dlopen('./primes/target/debug/libprimes.so')
+primal = ffi.dlopen(DLL)
 
 
 class Sieve:

--- a/src/strings/Makefile
+++ b/src/strings/Makefile
@@ -7,10 +7,10 @@ test: build
 
 
 main_chars: main_chars.c libchars.so
-	$(CC) -l chars -L . -o $@ $<
+	$(CC) $(CFLAGS) -l chars -L . -o $@ $<
 
 main_versions: main_versions.c libversions.so
-	$(CC) -l versions -L . -o $@ $<
+	$(CC) $(CFLAGS) -l versions -L . -o $@ $<
 
 
 lib%.so: %.rs

--- a/src/strings/Makefile
+++ b/src/strings/Makefile
@@ -1,16 +1,16 @@
 
-all: main_chars main_versions
+build: main_chars main_versions
 
-run: all
-	LD_LIBRARY_PATH=. ./main_chars
-	LD_LIBRARY_PATH=. ./main_versions
+test: build
+	LD_LIBRARY_PATH=. ./main_chars | grep '12 characters'
+	LD_LIBRARY_PATH=. ./main_versions | grep '0.1.0'
 
 
 main_chars: main_chars.c libchars.so
-	clang -l chars -L . -o $@ $<
+	$(CC) -l chars -L . -o $@ $<
 
 main_versions: main_versions.c libversions.so
-	clang -l versions -L . -o $@ $<
+	$(CC) -l versions -L . -o $@ $<
 
 
 lib%.so: %.rs
@@ -21,4 +21,4 @@ clean:
 	$(RM) main_versions
 	$(RM) main_chars
 
-.PHONY: clean run
+.PHONY: clean test

--- a/src/structs/Makefile
+++ b/src/structs/Makefile
@@ -1,0 +1,11 @@
+build:
+	cd get_usage && cargo build
+
+test: build
+	cd get_usage && cargo run | grep 'Usage { utime: Timeval { sec: '
+
+clean: 
+	cd get_usage && cargo clean
+
+.PHONY: clean test
+


### PR DESCRIPTION
This introduces a more organised scheme for building and testing the example code. Each chapter has its own `Makefile` which must define the following three rules: `build`, `test`, and `clean`. Allowing you to run `make test` in the top level directory and have `make test` be run in each chapter.

It also adds cargo workspaces so that the examples can share build artefacts instead of unnecessarily rebuilding common crates like `libc` half a dozen times.

cc: #29 