### PR TITLE
Fix typos and improve grammar

### DIFF
--- a/src/arrays/index.md
+++ b/src/arrays/index.md
@@ -1,6 +1,6 @@
 # Arrays
 
-Now that you've got the basics, lets try to do something a little more
+Now that you've got the basics, let's try to do something a little more
 interesting. Using arrays as function parameters.
 
 For a change, Rust will be used as a library (i.e. the "guest" language) and
@@ -65,7 +65,7 @@ Issues like these are important to keep in mind when writing `unsafe` rust,
 although they are probably quite familiar for people who've written C/C++ code
 before.
 
-Without further ado, lets compile the library.
+Without further ado, let's compile the library.
 <span id="rustc-static-notes"></span>
 ```bash
 $ rustc --crate-type staticlib -o libaverages.a averages.rs
@@ -136,7 +136,7 @@ about. When everything is statically compiled, **all** your dependencies must
 be included. This wasn't an issue when dynamically linking because the loader
 found everything for you.
 
-Okay, lets try again...
+Okay, let's try again...
 
 ```bash
 $ clang -l dl \

--- a/src/best_practices.md
+++ b/src/best_practices.md
@@ -26,7 +26,7 @@ In general, you'll want to:
 * Make sure that memory is only free'd from the language it was allocated in
 * Check for null pointers. Everywhere.
 * Document the assumptions which are normally enforced by the Rust type system 
-  like whether a function recieving a pointer gains ownership of the data being
+  like whether a function receiving a pointer gains ownership of the data being
   pointed to or is only taking it as a reference
 
 Where possible, try to enforce memory safety to prevent against accidental 

--- a/src/callbacks/index.md
+++ b/src/callbacks/index.md
@@ -42,7 +42,7 @@ a function which satisfies the function signature required.
 The biggest thing to worry about is ensuring the Rust callback's signature is
 *exactly* the same as the one your C program is expecting. If it isn't, this is
 **undefined behaviour** (roughly point [768] of the C spec) and will probably
-result in you recieving garbage then segfaulting when the function returns.
+result in you receiving garbage then segfaulting when the function returns.
 
 First, let's make a `typedef` for the callback function.
 

--- a/src/callbacks/index.md
+++ b/src/callbacks/index.md
@@ -44,7 +44,7 @@ The biggest thing to worry about is ensuring the Rust callback's signature is
 **undefined behaviour** (roughly point [768] of the C spec) and will probably
 result in you recieving garbage then segfaulting when the function returns.
 
-First, lets make a `typedef` for the callback function.
+First, let's make a `typedef` for the callback function.
 
 ```rust
 type Callback = unsafe extern "C" fn(c_int) -> c_int;
@@ -293,7 +293,7 @@ pub unsafe extern "C" fn get_item_10000(buffer: *const u8, len: usize) -> u8 {
 }
 ```
 
-Now lets call it from the following `main.c`:
+Now let's call it from the following `main.c`:
 
 
 ```c

--- a/src/pythonic/index.md
+++ b/src/pythonic/index.md
@@ -1,6 +1,6 @@
 # Making Rust Pythonic
 
-Lets give C a rest for a while and try to speed up our Python programs. For 
+Let's give C a rest for a while and try to speed up our Python programs. For
 this example we will build a *pythonic* interface to the amazing
 [primal][primal] crate.
 

--- a/src/pythonic/index.md
+++ b/src/pythonic/index.md
@@ -108,7 +108,7 @@ for conveying what you're doing.
 
 > **Hint:** when crossing the FFI boundary you tend to play fast and loose with
 > your pointers and data types. You'll notice that any function 
-> which is recieving raw pointers from an untrusted source (i.e. Python/C) 
+> which is receiving raw pointers from an untrusted source (i.e. Python/C) 
 > has been marked as `unsafe`. Typically you'd go to great lengths to document under what 
 > conditions the user will violate memory safety. The `# Safety` and `# Remarks` headers
 > in these doc-comments are used for each function which could provoke unsafe behaviour.

--- a/src/strings/index.md
+++ b/src/strings/index.md
@@ -3,11 +3,11 @@
 
 ## String Arguments
 
-Lets imagine you have an awesome Rust function which lets you count the number
+Let's imagine you have an awesome Rust function which lets you count the number
 of characters in any UTF-8 string, and you want to make it usable from your C
 code. How would you do this?
 
-First, lets define the Rust function:
+First, let's define the Rust function:
 
 ```rust
 fn count_chars(s: &str) -> usize {


### PR DESCRIPTION
Closes #19 
Fixes "recieving" typos
Change instances of "lets" that should be "let's"

