### PR TITLE
Update the existing cmake rules to be more DRY and organised

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,35 @@ endif ()
 # target name.
 function(rustc_library target_name source_file output_library)
     add_custom_command(OUTPUT ${output_library}
+        COMMENT "Compiling ${target_name}"
         COMMAND rustc --crate-type cdylib ${source_file} -o ${output_library}
         DEPENDS ${source_file})
     add_custom_target(${target_name} DEPENDS ${output_library})
 endfunction(rustc_library)
 
+
+# Compile a Rust crate and copy the *.so into the current binary dir. This 
+# also sets the LOCATION of the provided target to be the generated binary.
+#
+# A test target named ${target_name}_test is also generated.
+function(cargo_library target_name project_dir)
+    set(output_library ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/lib${target_name}.so)
+    file(GLOB sources ${project_dir}/src/**/*.rs)
+
+    add_custom_command(OUTPUT ${output_library}
+        COMMENT "Compiling ${target_name}"
+        COMMAND env CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} cargo build ${CARGO_RELEASE_FLAG}
+        COMMAND cp ${output_library} ${CMAKE_CURRENT_BINARY_DIR}
+        WORKING_DIRECTORY ${project_dir}
+        DEPENDS ${sources})
+
+    add_custom_target(${target_name} ALL DEPENDS ${output_library})
+    set_target_properties(${target_name} PROPERTIES LOCATION ${output_library})
+
+    add_test(NAME ${target_name}_test 
+        COMMAND env CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} cargo test ${CARGO_RELEASE_FLAG}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endfunction(cargo_library)
 
 enable_testing()
 add_subdirectory(client)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(CARGO_RELEASE_FLAG "" CACHE INTERNAL "")
     set(TARGET_DIR "debug" CACHE INTERNAL "")
 else ()
-    set(CARGO_RELEASE_FLAG --release CACHE INTERNAL "")
+    set(CARGO_RELEASE_FLAG "--release" CACHE INTERNAL "")
     set(TARGET_DIR "release" CACHE INTERNAL "")
 endif ()
 
@@ -29,8 +29,14 @@ function(cargo_library target_name project_dir)
     set(output_library ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/lib${target_name}.so)
     file(GLOB sources ${project_dir}/src/**/*.rs)
 
+    set(compile_message "Compiling ${target_name}")
+
+    if(CARGO_RELEASE_FLAG STREQUAL "--release")
+        set(compile_message "${compile_message} in release mode")
+    endif(CARGO_RELEASE_FLAG)
+
     add_custom_command(OUTPUT ${output_library}
-        COMMENT "Compiling ${target_name}"
+        COMMENT ${compile_message}
         COMMAND env CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} cargo build ${CARGO_RELEASE_FLAG}
         COMMAND cp ${output_library} ${CMAKE_CURRENT_BINARY_DIR}
         WORKING_DIRECTORY ${project_dir}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,28 @@
 cmake_minimum_required(VERSION 3.7)
 project(rest-client)
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(CARGO_RELEASE_FLAG "" CACHE INTERNAL "")
+    set(TARGET_DIR "debug" CACHE INTERNAL "")
+else ()
+    set(CARGO_RELEASE_FLAG --release CACHE INTERNAL "")
+    set(TARGET_DIR "release" CACHE INTERNAL "")
+endif ()
+
+
+# Compile a the provided source file to be a shared object with a custom 
+# target name.
+function(rustc_library target_name source_file output_library)
+    add_custom_command(OUTPUT ${output_library}
+        COMMAND rustc --crate-type cdylib ${source_file} -o ${output_library}
+        DEPENDS ${source_file})
+    add_custom_target(${target_name} DEPENDS ${output_library})
+endfunction(rustc_library)
+
+
 enable_testing()
 add_subdirectory(client)
 add_subdirectory(injector-plugin)
 add_subdirectory(gui)
+add_subdirectory(book/fun)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ function(rustc_library target_name source_file output_library)
         COMMAND rustc --crate-type cdylib ${source_file} -o ${output_library}
         DEPENDS ${source_file})
     add_custom_target(${target_name} DEPENDS ${output_library})
-endfunction(rustc_library)
+endfunction()
 
 
 # Compile a Rust crate and copy the *.so into the current binary dir. This 
@@ -33,7 +33,7 @@ function(cargo_library target_name project_dir)
 
     if(CARGO_RELEASE_FLAG STREQUAL "--release")
         set(compile_message "${compile_message} in release mode")
-    endif(CARGO_RELEASE_FLAG)
+    endif()
 
     add_custom_command(OUTPUT ${output_library}
         COMMENT ${compile_message}
@@ -48,7 +48,7 @@ function(cargo_library target_name project_dir)
     add_test(NAME ${target_name}_test 
         COMMAND env CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} cargo test ${CARGO_RELEASE_FLAG}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-endfunction(cargo_library)
+endfunction()
 
 enable_testing()
 add_subdirectory(client)

--- a/book/fun/CMakeLists.txt
+++ b/book/fun/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_subdirectory(problem_1)
+add_subdirectory(problem_2)
+add_subdirectory(problem_3)
+add_subdirectory(problem_4)

--- a/book/fun/problem_1/CMakeLists.txt
+++ b/book/fun/problem_1/CMakeLists.txt
@@ -1,0 +1,14 @@
+rustc_library(problem_1_lib 
+              ${CMAKE_CURRENT_SOURCE_DIR}/adder.rs 
+              ${CMAKE_CURRENT_BINARY_DIR}/libadder.so)
+
+option(WITH_PROBLEM_1 "Try to compile problem 1" OFF)
+
+if(WITH_PROBLEM_1)
+    add_executable(problem_1 ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+    target_link_libraries(problem_1 ${CMAKE_CURRENT_BINARY_DIR}/libadder.so)
+    add_dependencies(problem_1 problem_1_lib)
+
+    install(TARGETS problem_1 DESTINATION bin)
+endif(WITH_PROBLEM_1)
+

--- a/book/fun/problem_2/CMakeLists.txt
+++ b/book/fun/problem_2/CMakeLists.txt
@@ -1,0 +1,10 @@
+rustc_library(problem_2_lib 
+              ${CMAKE_CURRENT_SOURCE_DIR}/foo.rs 
+              ${CMAKE_CURRENT_BINARY_DIR}/libfoo.so)
+
+add_executable(problem_2 ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+target_link_libraries(problem_2 ${CMAKE_CURRENT_BINARY_DIR}/libfoo.so)
+add_dependencies(problem_2 problem_2_lib)
+
+install(TARGETS problem_2 DESTINATION bin)
+

--- a/book/fun/problem_3/CMakeLists.txt
+++ b/book/fun/problem_3/CMakeLists.txt
@@ -1,0 +1,9 @@
+rustc_library(problem_3_lib 
+              ${CMAKE_CURRENT_SOURCE_DIR}/home.rs 
+              ${CMAKE_CURRENT_BINARY_DIR}/libhome.so)
+
+add_executable(problem_3 ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+target_link_libraries(problem_3 ${CMAKE_CURRENT_BINARY_DIR}/libhome.so)
+add_dependencies(problem_3 problem_3_lib)
+
+install(TARGETS problem_3 DESTINATION bin)

--- a/book/fun/problem_4/CMakeLists.txt
+++ b/book/fun/problem_4/CMakeLists.txt
@@ -1,0 +1,9 @@
+rustc_library(problem_4_lib 
+              ${CMAKE_CURRENT_SOURCE_DIR}/logging.rs 
+              ${CMAKE_CURRENT_BINARY_DIR}/liblogging.so)
+
+add_executable(problem_4 ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+target_link_libraries(problem_4 ${CMAKE_CURRENT_BINARY_DIR}/liblogging.so)
+add_dependencies(problem_4 problem_4_lib)
+
+install(TARGETS problem_4 DESTINATION bin)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,20 +1,12 @@
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CARGO_CMD cargo build)
-    set(TARGET_DIR "debug")
-else ()
-    set(CARGO_CMD cargo build --release)
-    set(TARGET_DIR "release")
-endif ()
-
 set(CLIENT_SO "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libclient.so")
 
 add_custom_target(client
     COMMENT "Compiling client module"
-    COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} ${CARGO_CMD} 
+    COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} cargo build ${CARGO_RELEASE_FLAG} 
     COMMAND cp ${CLIENT_SO} ${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(client PROPERTIES LOCATION ${CMAKE_CURRENT_BINARY_DIR})
 
 add_test(NAME client_test 
-    COMMAND cargo test
+    COMMAND cargo test ${CARGO_RELEASE_FLAG}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,12 +1,1 @@
-set(CLIENT_SO "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libclient.so")
-
-add_custom_target(client
-    COMMENT "Compiling client module"
-    COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} cargo build ${CARGO_RELEASE_FLAG} 
-    COMMAND cp ${CLIENT_SO} ${CMAKE_CURRENT_BINARY_DIR}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-set_target_properties(client PROPERTIES LOCATION ${CMAKE_CURRENT_BINARY_DIR})
-
-add_test(NAME client_test 
-    COMMAND cargo test ${CARGO_RELEASE_FLAG}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+cargo_library(client ${CMAKE_CURRENT_SOURCE_DIR})

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -17,3 +17,5 @@ get_target_property(CLIENT_DIR client LOCATION)
 target_link_libraries(gui Qt5::Widgets)
 target_link_libraries(gui ${CLIENT_DIR}/libclient.so)
 add_dependencies(gui client)
+
+install(TARGETS gui DESTINATION bin)

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -13,9 +13,9 @@ set(SOURCE main_window.cpp main_window.hpp wrappers.cpp wrappers.hpp main.cpp)
 
 add_executable(gui ${SOURCE})
 
-get_target_property(CLIENT_DIR client LOCATION)
+get_target_property(CLIENT_SO client LOCATION)
 target_link_libraries(gui Qt5::Widgets)
-target_link_libraries(gui ${CLIENT_DIR}/libclient.so)
+target_link_libraries(gui ${CLIENT_SO})
 add_dependencies(gui client)
 
 install(TARGETS gui DESTINATION bin)

--- a/injector-plugin/CMakeLists.txt
+++ b/injector-plugin/CMakeLists.txt
@@ -1,16 +1,2 @@
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CARGO_CMD cargo build)
-    set(TARGET_DIR "debug")
-else ()
-    set(CARGO_CMD cargo build --release)
-    set(TARGET_DIR "release")
-endif ()
-
-set(CLIENT_SO "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/libinjector_plugin.so")
-
-add_custom_target(injector_plugin ALL
-    COMMENT "Compiling injector_plugin module"
-    COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} ${CARGO_CMD} 
-    COMMAND cp ${CLIENT_SO} ${CMAKE_CURRENT_BINARY_DIR}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-set_target_properties(injector_plugin PROPERTIES LOCATION ${CMAKE_CURRENT_BINARY_DIR})
+cargo_library(injector_plugin ${CMAKE_CURRENT_SOURCE_DIR})
+add_dependencies(injector_plugin client)


### PR DESCRIPTION
I tried to clean up the existing `CMakeLists.txt` files so they are more DRY and organised instead of being a bunch of things I've just hacked together to make things work. If you run `cmake .. && make` that should be enough to build all the "fun" problems, the entire REST client app, and everything they depend on.