### PR TITLE
Use --lib to create a Cargo library

### DIFF
--- a/book/setting_up.md
+++ b/book/setting_up.md
@@ -91,7 +91,7 @@ hasn't yet been configured.
 Next we need to create the Rust project.
 
 ```
-$ cargo new client
+$ cargo new --lib client
 ```
 
 To make it accessible from C++ we need to make sure `cargo` generates a 


### PR DESCRIPTION
Cargo's default target when creating a new project is a binary target, meaning a project with a `main.rs`. Since we want a library, we have to be explicit and use the `--lib` flag when initialising the project.